### PR TITLE
writeN fix

### DIFF
--- a/PCA9635.cpp
+++ b/PCA9635.cpp
@@ -90,10 +90,10 @@ uint8_t PCA9635::write3(uint8_t channel, uint8_t R, uint8_t G, uint8_t B)
 
 
 // write count values in consecutive PWM registers
-// checks if [channel + count >= 16]
+// checks if [channel + count - 1 > 15]
 uint8_t PCA9635::writeN(uint8_t channel, uint8_t* arr, uint8_t count)
 {
-  if (channel + count > 15)
+  if (channel + count > 16)
   {
     _error = PCA9635_ERR_WRITE;
     return PCA9635_ERROR;


### PR DESCRIPTION
`writeN` input check fix:
The function is taking three arguments: the 'base' channel, an array of PWM values and the array size.
The check `(channel + count > 15)` does not takie into account that the first value is written to `channel` and last to `channel + count - 1`, which means there any writes to address 15 are returning the _PCA9635_ERR_WRITE_ error.